### PR TITLE
Accept speech recognition results with both ß and ss

### DIFF
--- a/A1/public/script.js
+++ b/A1/public/script.js
@@ -296,7 +296,7 @@ function finishGame(){
         // Remove special characters from current_trigger 
         current_trigger = current_trigger.replace(/\n/g,"");
         if(paragraphs.length > 1) {
-          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
             paragraphs[paragraphs.length - 2].style.color = "green";
             if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
               sleepFor(2, toolAnswer);
@@ -345,7 +345,7 @@ function finishGame(){
       // Remove special characters from current_trigger 
       current_trigger = current_trigger.replace(/\n/g,"");
       if(paragraphs.length > 1) {
-        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
           paragraphs[paragraphs.length - 2].style.color = "green";
           if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
             sleepFor(2, toolAnswer);

--- a/A2/public/script.js
+++ b/A2/public/script.js
@@ -297,7 +297,7 @@ function finishGame(){
         // Remove special characters from current_trigger 
         current_trigger = current_trigger.replace(/\n/g,"");
         if(paragraphs.length > 1) {
-          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
             paragraphs[paragraphs.length - 2].style.color = "green";
             if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
               sleepFor(2, toolAnswer);
@@ -347,7 +347,7 @@ function finishGame(){
       // Remove special characters from current_trigger 
       current_trigger = current_trigger.replace(/\n/g,"");
       if(paragraphs.length > 1) {
-        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
           paragraphs[paragraphs.length - 2].style.color = "green";
           if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
             sleepFor(2, toolAnswer);

--- a/B1/public/script.js
+++ b/B1/public/script.js
@@ -296,7 +296,7 @@ function finishGame(){
         // Remove special characters from current_trigger 
         current_trigger = current_trigger.replace(/\n/g,"");
         if(paragraphs.length > 1) {
-          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
             paragraphs[paragraphs.length - 2].style.color = "green";
             if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
               sleepFor(2, toolAnswer);
@@ -345,7 +345,7 @@ function finishGame(){
       // Remove special characters from current_trigger 
       current_trigger = current_trigger.replace(/\n/g,"");
       if(paragraphs.length > 1) {
-        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
           paragraphs[paragraphs.length - 2].style.color = "green";
           if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
             sleepFor(2, toolAnswer);

--- a/B2/public/script.js
+++ b/B2/public/script.js
@@ -296,7 +296,7 @@ function finishGame(){
         // Remove special characters from current_trigger 
         current_trigger = current_trigger.replace(/\n/g,"");
         if(paragraphs.length > 1) {
-          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+          if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
             paragraphs[paragraphs.length - 2].style.color = "green";
             if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
               sleepFor(2, toolAnswer);
@@ -345,7 +345,7 @@ function finishGame(){
       // Remove special characters from current_trigger 
       current_trigger = current_trigger.replace(/\n/g,"");
       if(paragraphs.length > 1) {
-        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"") == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"")){
+        if(paragraphs[paragraphs.length - 2].innerText.toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss') == allTriggerAnswersData[0][current_trigger][current_trigger_index].toLowerCase().replace(/[.,?!;:]/g,"").replace(/ß/gi, 'ss')){
           paragraphs[paragraphs.length - 2].style.color = "green";
           if(allTriggerAnswersData[0][current_trigger][current_trigger_index + 1]){
             sleepFor(2, toolAnswer);


### PR DESCRIPTION
This change fixes the problem reported in
https://community.smartergerman.com/c/post-any-question-here/a2-42-assisted-preaching-problems-with-entering-ss affecting those of us living in Switzerland and using Chrome.

I updated only the versions of these files that were most recently updated & are actually used in the course. There are different versions of script.js under v1/ and v2/ subdirectories as well, but they seem to be unused & contain older versions of the tool, so I did not update them.

I tested locally that the fix works for me by replacing script.js with my version using the browser's Dev Tools.